### PR TITLE
Add case insensitivity to exclude file extensions regex pattern 

### DIFF
--- a/AIOStreams Templates/Tamtaro-complete-setup-template.json
+++ b/AIOStreams Templates/Tamtaro-complete-setup-template.json
@@ -2541,7 +2541,7 @@
       "DivX"
     ],
     "excludedRegexPatterns": [
-      "\\.(iso|r\\d{2}|zip|rar|7z|tar|gz|zipx|arj|txt|nfo|jpg|png|pdf|exe|bat|cmd|scr|msi|ps1|vbs|js|jar|com|pif|reg|dll|sys|lnk|url)$"
+      "(!?)\\.(iso|r\\d{2}|zip|rar|7z|tar|gz|zipx|arj|txt|nfo|jpg|png|pdf|exe|bat|cmd|scr|msi|ps1|vbs|js|jar|com|pif|reg|dll|sys|lnk|url)$"
     ],
     "includedRegexPatterns": [],
     "requiredRegexPatterns": [],


### PR DESCRIPTION
file extensions exclusion regex pattern is case sensitive so I preppended "(?i)" to make it case insensitive, to cover ".ISO" extensions for example.