### PR TITLE
Fix redundant Usenet SEL condition

### DIFF
--- a/AIOStreams Templates/Tamtaro-complete-setup-template.json
+++ b/AIOStreams Templates/Tamtaro-complete-setup-template.json
@@ -2696,7 +2696,7 @@
         "enabled": true
       },
       {
-        "__if": "inputs.coreFilterUsenet == 0 and inputs.coreFilterUsenet == 0",
+        "__if": "inputs.coreFilterUsenet == 0",
         "expression": "/*𝚃𝚊𝚖𝚝𝚊𝚛𝚘 𝙲𝚘𝚖𝚙𝚕𝚎𝚝𝚎 𝚂𝙴𝙻 𝚂𝚎𝚝𝚞𝚙 𝚟3.0.4: No 𝚂𝙴𝙻𝚎𝚌𝚝 𝙴𝚗𝚐𝚒𝚗𝚎*/ []",
         "enabled": true
       },


### PR DESCRIPTION
## Summary

Removes a redundant condition.

## Changes

The condition was simplified from:

`inputs.coreFilterUsenet == 0 and inputs.coreFilterUsenet == 0`

to:

`inputs.coreFilterUsenet == 0`

## Impact

This preserves the existing behavior while removing the duplicated comparison and making the condition clearer and easier to maintain.

No filtering thresholds or stream-selection logic were changed.